### PR TITLE
add IRIS connect

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@
 ## Sonstiges
 
 - Freifunk ([GitHub](https://github.com/freifunk))
+- [IRIS connect](https://iris-connect.de) ([GitHub](https://github.com/iris-connect/))
 
 ## Du willst mitarbeiten?
 


### PR DESCRIPTION
IRIS connect hilft Gesundheitsämtern zu kommunizieren. Bisher in 4 Bundesländern.